### PR TITLE
Resolved Warnings

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -1,4 +1,3 @@
-
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -7,8 +6,6 @@
 #define MEMCHECK 0
 
 #include "../cutils.h"
-
-
 
 #define MAX_PTRS 8192
 
@@ -97,15 +94,24 @@ void* dbg_calloc(size_t nmemb, size_t size, char* file, int line)
     return ptr;
 }
 
-void* dbg_realloc(void* ptr, size_t size, char* file, int line)
-{
+void* dbg_realloc(void* ptr, size_t size, char* file, int line) {
     dbg(4, "dbg_realloc: %s:%d %p %zu->%zu bytes", file, line, ptr, malloc_usable_size(ptr), size);
+
+    // Unlog the pointer before reallocating
+    unlog_ptr(ptr, file, line);
+
+    // Reallocate memory
     void* newptr = realloc(ptr, size);
+
+    // Check for allocation failure
     if (newptr == NULL) {
         msg(ERROR, "\trealloc failed");
+        return NULL; // Return NULL on failure
     }
-    unlog_ptr(ptr, file, line);
+
+    // Log the new pointer
     log_ptr(newptr, file, line);
+
     return newptr;
 }
 
@@ -136,4 +142,3 @@ void dbg_free(void* ptr, char* file, int line)
     }
     free(ptr);
 }
-

--- a/src/system.c
+++ b/src/system.c
@@ -209,7 +209,9 @@ int mvlink(char* old_path,char* new_path)
     //strncpy(new_link,parent_path,strlen(parent_path));
 
     // add the separator
-    if (new_link[strlen(new_link)-1] != '/') strncat(new_link,"/",1);
+    if (new_link[strlen(new_link) - 1] != '/') {
+    	strncat(new_link, "/", 2); // Reserve space for the null terminator
+    }
 
     //strncat(new_link,rel_path,strlen(rel_path));
 
@@ -289,4 +291,3 @@ int mvsp(char* old_path,char* new_path)
     
     return 0;
 }
-


### PR DESCRIPTION
Resolved these warnings:

src/mem.c: In function ‘dbg_realloc’:
src/mem.c:107:5: warning: pointer ‘ptr’ used after ‘realloc’ [-Wuse-after-free]
  107 |     unlog_ptr(ptr, file, line);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/mem.c:103:20: note: call to ‘realloc’ here
  103 |     void* newptr = realloc(ptr, size);
      |                    ^~~~~~~~~~~~~~~~~~

src/system.c: In function ‘mvlink’:
src/system.c:212:46: warning: ‘strncat’ specified bound 1 equals source length [-Wstringop-overflow=]
  212 |     if (new_link[strlen(new_link)-1] != '/') strncat(new_link,"/",1);
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~