### PR TITLE
Update system.c

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -154,26 +154,31 @@ char* relpath(char* start,char* end) {
         tmp++;
     }
     i++;
+    
     // then get the path from old_path to the common prefix
     char* part_path = start+i;
-    // sanitize by removing the last '/'
-    if (part_path[strlen(part_path)-1] == '/') part_path[strlen(part_path)-1] = '\0';
- 
+    
+    // Sanitize by removing the last '/'
+    size_t len = strlen(part_path);
+    if (len > 0 && part_path[len - 1] == '/') {
+        part_path[len - 1] = '\0';
+    }
 
     int count = 0;
-    for (int j = 0; j < strlen(part_path); j++) {
+    for (size_t j = 0; j < strlen(part_path); j++) {
         if (part_path[j] == '/') count++;
     }
-    // create the relative path
+
+    // Create the relative path
     char rel_path[2048] = {0};
     for (int j = 0; j < count; j++) {
-        strncat(rel_path,"../",4);
+        strncat(rel_path, "../", 4);
     }
-    // add the remaining part of the link
-    strncat(rel_path,end+i,strlen(end)-i);
 
-    // 
-    return strdup(rel_path);
+    // Add the remaining part of the link
+    strncat(rel_path, end + i, strlen(end) - i);
+
+    return strdup(rel_path);    
 
 }
 


### PR DESCRIPTION
Noticed this warning when using a custom Makefile:

src/system.c: In function ‘relpath’:
src/system.c:164:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  164 |     for (int j = 0; j < strlen(part_path); j++) {
      |                       ^

I made adjustments to resolve this.